### PR TITLE
PR:2 Pass in a list of command args as the second bash argument and xargs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -40,6 +40,7 @@ Also chain using the ``xargs`` function to map the results of the previous comma
     'setup.py:    author=\'Alex Couper\','
 
 Equivalently::
+
     >>> files = [f for f in bash('ls').bash('grep "\.py"')]
     >>> bash('grep "author=\'Alex Couper\'"', files)
     'setup.py:    author=\'Alex Couper\','

--- a/README.rst
+++ b/README.rst
@@ -60,6 +60,15 @@ To get a stripped, unicode string version of bash.stdout call value()::
     >>> b = bash('ls tests.py').value()
     u'tests.py'
 
+To get the results (separated by newlines) as a list::
+
+    >>> b = bash('ls . ').results()
+    ['bash.pyc', 'tests.pyc']
+
+or use the iterator directly::
+
+    >>> b = [res for res in bash('ls . ')]
+    ['bash.pyc', 'tests.pyc']
 
 Motivation
 ----------

--- a/README.rst
+++ b/README.rst
@@ -22,11 +22,28 @@ Run commands as you would in bash::
     bash.pyc
     tests.pyc
 
-Chain commands for the same effect::
+Pass in arguments as an array::
+
+    >>> bash('ls', ['.'])
+    bash.pyc
+    tests.pyc
+
+Chain commands for the same pipe effect as above::
 
     >>> bash('ls . ').bash('grep ".pyc"')
     bash.pyc
     tests.pyc
+
+Also chain using the ``xargs`` function to map the results of the previous command onto a new command::
+
+    >>> bash('ls').bash('grep "\.py"').xargs('grep "author=\'Alex Couper\'"')
+    'setup.py:    author=\'Alex Couper\','
+
+Equivalently::
+    >>> files = [f for f in bash('ls').bash('grep "\.py"')]
+    >>> bash('grep "author=\'Alex Couper\'"', files)
+    'setup.py:    author=\'Alex Couper\','
+
 
 This becomes increasingly useful if you later need to reuse one such command::
 

--- a/bash/__init__.py
+++ b/bash/__init__.py
@@ -43,6 +43,14 @@ class bash(object):
         self.code = self.p.returncode
         return self
 
+    def xargs(self, *cmds, **kwargs):
+        bash.commandChecker(cmds)
+        args = cmds[1] if bash.areMultipleArgs(cmds) else []
+        xargs = self.results()
+        passThroughCmds = [cmds[0], [*args, *xargs]]
+        print(passThroughCmds)
+        return self.bash(*passThroughCmds, **kwargs)
+
     def __repr__(self):
         return self.value()
 

--- a/bash/__init__.py
+++ b/bash/__init__.py
@@ -1,3 +1,4 @@
+import re
 import sys
 from subprocess import PIPE, Popen
 SUBPROCESS_HAS_TIMEOUT = True
@@ -8,6 +9,8 @@ if sys.version_info < (3, 0):
         # You haven't got subprocess32 installed. If you're running 2.X this
         # will mean you don't have access to things like timeout
         SUBPROCESS_HAS_TIMEOUT = False
+
+SPLIT_NEWLINE_REGEX = re.compile(' *\n *')
 
 
 class bash(object):
@@ -58,3 +61,10 @@ class bash(object):
         if self.stdout:
             return self.stdout.strip().decode(encoding='UTF-8')
         return ''
+
+    def results(self):
+        output = self.stdout.decode(encoding='UTF-8').strip() or ''
+        if output:
+            return SPLIT_NEWLINE_REGEX.split(output)
+        else:
+            return []

--- a/bash/__init__.py
+++ b/bash/__init__.py
@@ -57,6 +57,9 @@ class bash(object):
     def __bool__(self):
         return bool(self.value())
 
+    def __iter__(self):
+        return self.results().__iter__()
+
     def value(self):
         if self.stdout:
             return self.stdout.strip().decode(encoding='UTF-8')

--- a/tests.py
+++ b/tests.py
@@ -75,3 +75,65 @@ class TestBash(unittest.TestCase):
 
         iteratedResults = [result for result in b]
         self.assertEqual(iteratedResults, expecting)
+
+    def test_accept_args_list(self):
+        expecting = ['setup.py', 'tests.py']
+        b = bash('ls').bash('grep', ['-e', '"\.py"'])
+        results = b.results()
+        self.assertEqual(results, expecting)
+
+    def test_syntax_error_no_args(self):
+        with self.assertRaises(SyntaxError) as e:
+            bash()
+
+        self.assertEqual(
+            str(e.exception),
+            'no arguments\n' + 
+            'bash and xargs will accept one or two arguments: [command <str>, arguments <list of strings>]'
+        )
+
+    def test_syntax_error_not_string_arg(self):
+        with self.assertRaises(SyntaxError) as e:
+            bash(1)
+
+        self.assertEqual(
+            str(e.exception),
+            'first argument to bash must be a command as a string\n' + 
+            'bash and xargs will accept one or two arguments: [command <str>, arguments <list of strings>]'
+        )
+
+    def test_syntax_error_second_arg_not_list(self):
+        with self.assertRaises(SyntaxError) as e:
+            bash('a', 'b')
+
+        self.assertEqual(
+            str(e.exception),
+            'second argument to bash (if specified) must be a list of strings\n' + 
+            'bash and xargs will accept one or two arguments: [command <str>, arguments <list of strings>]'
+        )
+
+    def test_syntax_error_second_arg_not_list_of_strings(self):
+        with self.assertRaises(SyntaxError) as e:
+            bash('a', [1])
+
+        self.assertEqual(
+            str(e.exception),
+            'one or more command arguments were not strings\n' + 
+            'bash and xargs will accept one or two arguments: [command <str>, arguments <list of strings>]'
+        )
+
+    def test_syntax_error_second_arg_not_list_of_strings(self):
+        with self.assertRaises(SyntaxError) as e:
+            bash('a', ['b'], 'c')
+
+        self.assertEqual(
+            str(e.exception),
+            'more than two bash arguments given\n' + 
+            'bash and xargs will accept one or two arguments: [command <str>, arguments <list of strings>]'
+        )
+
+    def test_xargs(self):
+        expecting = 'setup.py:    author=\'Alex Couper\','
+        result = bash('ls').bash('grep', ['-e', '"\.py"']).xargs('grep', ['"author=\'Alex Couper\'"']).value()
+        self.assertEqual(result, expecting)
+

--- a/tests.py
+++ b/tests.py
@@ -66,3 +66,12 @@ class TestBash(unittest.TestCase):
         self.assertTrue((t2-t1).total_seconds() < 0.5)
         b.sync()
         self.assertEqual(b.stdout, b'1\n')
+
+    def test_iterate_over_results(self):
+        expecting = ['setup.py', 'tests.py']
+        b = bash('ls . | grep "\.py"')
+        results = b.results()
+        self.assertEqual(results, expecting)
+
+        iteratedResults = [result for result in b]
+        self.assertEqual(iteratedResults, expecting)


### PR DESCRIPTION
(includes PR:1, can be merged instead of PR:1)

The passed in list will be checked for correctness, unpacked and appended to the orginal command

From updated readme:

 ---

Pass in arguments as an array::

    >>> bash('ls', ['.'])
    bash.pyc
    tests.pyc

---

Because arguments can now be passed in as a list and because we can get the results of the previous call as a list: we can implement the `xargs` function. Where the results of the previous call are mapped onto the next function:

---

    >>> bash('ls').bash('grep "\.py"').xargs('grep "author=\'Alex Couper\'"')
    'setup.py:    author=\'Alex Couper\','

Which is similar to, but not exactly the same as (due to how grep works):

    >>> results = [f for f in bash('ls').bash('grep "\.py"')]
    >>> list(map(
                  lambda f: [f, bash('grep "author=\'Alex Couper\'"' + f)]
             ))
    [  [''setup.py', '    author=\'Alex Couper\',']  ]
---
